### PR TITLE
Add a fallback for loading files, and cache them.

### DIFF
--- a/src/inline.js
+++ b/src/inline.js
@@ -3,24 +3,64 @@
 
   module.directive('ngInline', [
     '$templateCache',
-    function($templateCache) {
+    function($templateCache, $compile, $http, $q) {
+      var utils    = {};
+      /**
+       * Load an external file through $http.
+       * @param  {String} templateId [Template name, or file path]
+       * @return {Promise}           [Return a promise]
+       */
+      utils.superCache = function (templateId) {
+        var fn = {}, deferred;
+
+        // Save & pass the loaded template
+        fn.success = function (data) {
+          console.info('loaded and cached:', templateId);
+          // Save template in cache
+          $templateCache.put(templateId, data);
+          // Return the template.
+          deferred.resolve(data);
+        };
+        // Pass an error message
+        fn.failed = function (message) {
+          deferred.reject('cache failed:', message);
+        };
+
+
+        deferred = $q.defer();
+
+        $http.get(templateId).success(fn.success).error(fn.failed);
+        return deferred.promise;
+      };
+
       return {
         restrict: 'A',
         priority: 400, // Same as ng-include.
-        compile: function(element, attrs){
-          var templateName = attrs.ngInline;
+        compile: function(element, attrs) {
+          var templateName,
+            template;
+
+          templateName = attrs.ngInline;
+
           if(!templateName){
             throw new Error('ngInline: expected template name');
           }
 
-          var template = $templateCache.get(templateName);
+          template = $templateCache.get(templateName);
           if(angular.isUndefined(template)){
-            throw new Error('ngInline: unknown template ' + templateName);
-          }
+            return function(scope, element){
 
-          element.html(template);
+              utils.superCache(templateName).then(function(tpl) {
+
+                element.html(tpl);
+                $compile(element.contents())(scope);
+
+              }, console.log );
+            };
+          } else {
+            element.html(template);
+          }
         }
       };
-    }
-  ]);
+    });
 })();


### PR DESCRIPTION
There is one issue remaining:

When loading files on an ng-repeat, template will be called multiples time and fire multiple http requests.
The only workaround I can see for this is to pre-load the template we will use into ng-repeat. This way the will only be loaded once. This is not needed for normal / singles ng-inline.
